### PR TITLE
Adding User-agent, resume cancelled/failed download

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 ./receipe_download/*
 scraper/node_modules/*
 downloader/node_modules/*
-downloader/html/*
+downloader/html/*.html
 

--- a/downloader/html/KEEP.md
+++ b/downloader/html/KEEP.md
@@ -1,0 +1,1 @@
+Keep this file

--- a/downloader/index.js
+++ b/downloader/index.js
@@ -5,6 +5,8 @@ let Parser = require('./parser.js');
 let async = require('async');
 let fs = require('fs');
 
+let concurrent_http_requests = 10;
+
 function getSiteMap() {
   return new Promise((resolve, reject) => {
      request.get({"url": "http://www.bbc.co.uk/food/sitemap.xml"}, (err,res,body) => {
@@ -16,15 +18,20 @@ function getSiteMap() {
    });
 }
 
+function getOutfile(url) {
+   let outfile = url.substring(url.lastIndexOf("\/\/")+2);
+   outfile = outfile.replace(/\//g, "_");
+   outfile = outfile.replace(/\./g, "_") + ".html";
+   return outfile;
+}
+
 getSiteMap()
 .then((urls)=> {
     return new Promise((resolve, reject) => {
         var tasks = [];
         urls.forEach((url) => {
             if(url.length > 0) {
-                let outfile = url.substring(url.lastIndexOf("\/\/")+2);
-                outfile = outfile.replace(/\//g, "_");
-                outfile = outfile.replace(/\./g, "_") + ".html";
+                let outfile = getOutfile(url);
                 tasks.push({ url: url, outfile: outfile });
             }
         });
@@ -32,17 +39,19 @@ getSiteMap()
     });
 })
 .then(tasks => {
-  console.log("tasks ready " + tasks.length);
+  console.log("Downloading: " + tasks.length+ " URLs.");
   var q = async.queue((task, done) => {
       process.stdout.write(".")
-      request.get(task.url, (err,res,body) => {
+
+      var req = {url:task.url, headers: {"User-Agent":"auntiesreciples downloader" }};
+      request.get(req, (err,res,body) => {
           fs.writeFile("html/" + task.outfile, body, "utf8", () => {
               process.stdout.write("-")
             // console.log("Written: " + task.outfile);
             setImmediate(done);              
           });
       });
-  }, 10);
+  }, concurrent_http_requests);
   q.drain = () => {
       console.log("Everything has been downloaded.")
   };

--- a/downloader/index.js
+++ b/downloader/index.js
@@ -45,11 +45,17 @@ getSiteMap()
 
       var req = {url:task.url, headers: {"User-Agent":"auntiesreciples downloader" }};
       request.get(req, (err,res,body) => {
+        fs.exists("html/" + task.outfile, function(exists) {
+          if(exists) {
+             process.stdout.write("/")
+             return setImmediate(done);
+          }
           fs.writeFile("html/" + task.outfile, body, "utf8", () => {
               process.stdout.write("-")
             // console.log("Written: " + task.outfile);
             setImmediate(done);              
           });
+        });
       });
   }, concurrent_http_requests);
   q.drain = () => {

--- a/downloader/index.js
+++ b/downloader/index.js
@@ -43,20 +43,20 @@ getSiteMap()
   var q = async.queue((task, done) => {
       process.stdout.write(".")
 
-      var req = {url:task.url, headers: {"User-Agent":"auntiesreciples downloader" }};
-      request.get(req, (err,res,body) => {
-        fs.exists("html/" + task.outfile, function(exists) {
-          if(exists) {
-             process.stdout.write("/")
-             return setImmediate(done);
-          }
+      fs.exists("html/" + task.outfile, function(exists) {
+        if(exists) {
+           process.stdout.write("/")
+           return done();
+        }
+        var req = {url:task.url, headers: {"User-Agent":"auntiesreciples downloader" }};
+        request.get(req, (err,res,body) => {
           fs.writeFile("html/" + task.outfile, body, "utf8", () => {
-              process.stdout.write("-")
-            // console.log("Written: " + task.outfile);
-            setImmediate(done);              
+             process.stdout.write("-")
+             // console.log("Written: " + task.outfile);
+             setImmediate(done);
           });
         });
-      });
+       });
   }, concurrent_http_requests);
   q.drain = () => {
       console.log("Everything has been downloaded.")


### PR DESCRIPTION
Hi, no rush with this one, I've made some enhacements that I think are needed.
- adding User-agent (polite when scraping)
- resume cancelled/failed download - skips files already existing
- tidy up the safe filename generation

Also I saw a bigger number than yourself when downloading the HTML.

```
$ du -h html/
1.3G    html/
$ du -m html/
1295    html/
$ du -k html/
1325444 html/

$ ls -l html/|wc -l
15974
```

Are you sure wget isn't missing some? I think I saw some weird/missed output from the egrep.

Give this a whirl if you have a chance.
